### PR TITLE
Improved memory usage

### DIFF
--- a/src/Meanbee/DownloadRemoteMedia/Commands/DownloadRemoteMedia.php
+++ b/src/Meanbee/DownloadRemoteMedia/Commands/DownloadRemoteMedia.php
@@ -18,6 +18,7 @@ class DownloadRemoteMedia extends AbstractCommand
         $this
             ->setName('media:fetch:products')
             ->addOption('remote-url', null, InputOption::VALUE_REQUIRED, 'The URL images should be fetched from')
+            ->addOption('store', null, InputOption::VALUE_OPTIONAL, 'store code, defaults to "default"', 'default')
             ->addOption('skus', null, InputOption::VALUE_OPTIONAL, 'CSV of SKUs to fetch images for')
             ->addOption('show-skipped', null, InputOption::VALUE_OPTIONAL, 'Hide/show messages that can skipped (defaults to hidden, useful for debugging)')
             ->addOption('image-attributes', null, InputOption::VALUE_OPTIONAL, 'CSV of Image attributes you would like to download, defaults to just the base image.')
@@ -37,22 +38,47 @@ class DownloadRemoteMedia extends AbstractCommand
 
         $this->detectMagento($this->getOutput());
         if ($this->initMagento()) {
-            $remote_url = $this->validateUrl($this->getInput()->getOption('remote-url'));
+            // By choosing a store, we'll limit images to products in that store.
+            // Plus, magerun uses the admin store by default, which means flat tables aren't used.
+            $store = $this->getInput()->getOption('store');
+            \Mage::app()->setCurrentStore($store);
             $this->prepareImageAttributes();
-            $this->fetchImagesFromRemote($remote_url);
+
+            $remote_url = $this->validateUrl($this->getInput()->getOption('remote-url'));
+            $media_config = \Mage::getModel('catalog/product')->getMediaConfig();
+            $collection = $this->prepareCollection();
+
+            // We're using an iterator to reduce the amount data loaded into memory. As we don't need full catalog/product objects.
+            /** @var \Mage_Core_Model_Resource_Iterator $iterator */
+            $iterator = \Mage::getResourceSingleton('core/iterator');
+            $iterator->walk(
+                $collection->getSelect(),
+                array(
+                    array(
+                        $this,
+                        'fetchImagesFromRemote'
+                    )
+                ),
+                array(
+                    'remote_url' => $remote_url,
+                    'media_config' => $media_config
+                )
+            );
         }
     }
 
-    public function fetchImagesFromRemote($remote_url)
+    public function fetchImagesFromRemote($data)
     {
-        $collection = $this->prepareCollection();
+        $remote_url = $data['remote_url'];
+        $media_config = $data['media_config'];
 
-        /** @var \Mage_Catalog_Model_Product $product */
-        foreach ($collection as $product) {
-            $this->current_product = $product;
-            foreach ($this->getImageAttributes() as $image) {
-                $this->downloadImages($product, $image, $product->getMediaConfig(), $remote_url);
+        foreach ($this->getImageAttributes() as $image_attribute) {
+            if (!isset($data['row'][$image_attribute])) {
+                continue;
             }
+
+            $image = $data['row'][$image_attribute];
+            $this->downloadImages($image, $image_attribute, $media_config, $remote_url);
         }
     }
 
@@ -63,14 +89,12 @@ class DownloadRemoteMedia extends AbstractCommand
     {
         /** @var \Mage_Catalog_Model_Resource_Product_Collection $collection */
         $collection = \Mage::getModel('catalog/product')->getCollection();
-
         $collection->addAttributeToSelect($this->getImageAttributes());
 
         $skus = $this->getSkus();
         if (!empty($skus)) {
             $collection->addAttributeToFilter('sku', array('in' => $skus));
         }
-        $collection->load();
         return $collection;
     }
 
@@ -88,14 +112,13 @@ class DownloadRemoteMedia extends AbstractCommand
 
     /**
      *
-     * @param \Mage_Catalog_Model_Product $product
+     * @param string $image
      * @param string $image_attribute
      * @param \Mage_Catalog_Model_Product_Media_Config $media_config
      * @param $remote_url
      */
-    protected function downloadImages($product, $image_attribute, $media_config, $remote_url)
+    protected function downloadImages($image, $image_attribute, $media_config, $remote_url)
     {
-        $image = $product->getData($image_attribute);
         $base_path = $media_config->getBaseMediaPath();
         $local_file = $base_path . $image;
 
@@ -116,7 +139,7 @@ class DownloadRemoteMedia extends AbstractCommand
         }
 
         $local_file_dir = dirname($local_file);
-        $directory_exists =  $this->createDirectories($local_file_dir);
+        $directory_exists = $this->createDirectories($local_file_dir);
         if (!$directory_exists) {
             return;
         }
@@ -139,7 +162,7 @@ class DownloadRemoteMedia extends AbstractCommand
     protected function createDirectories($path)
     {
         if (is_dir($path) && !is_writable($path)) {
-            $this->log("Directory exists, but isn't writeable");
+            $this->log("Directory exists, but isn't writable");
             return false;
         }
 
@@ -206,7 +229,7 @@ class DownloadRemoteMedia extends AbstractCommand
      */
     protected function showSkipped()
     {
-        return (bool) $this->getInput()->getOption('show-skipped');
+        return (bool)$this->getInput()->getOption('show-skipped');
     }
 
 }


### PR DESCRIPTION
There are two parts to this. 

First, you can now define the store you wish to use. This in it self will improve memory usage, as we won't be fetching all products from all stores, instead it'll just default to default store. Not only this, but if flat tables are used, they'll now be used by defining a store. This is because 98-magerun defaults to using the admin store, where flat tables are not used.

Secondly, we're now using an iterator. This saves us from loading the entire product collection into memory. You'll notice significant drop in memory usage.

This will fix #2
